### PR TITLE
Docker API updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 install:
   - sudo pip install urllib3
   - sudo pip install pytest
-  - sudo pip install docker-py==1.7.1
+  - sudo pip install docker-py==1.10.6
   - sudo util/install.sh
   - sudo make develop
   - docker pull ubuntu:trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 install:
   - sudo pip install urllib3
   - sudo pip install pytest
-  - sudo pip install docker-py==1.10.6
+  - sudo pip install docker==2.0.2
   - sudo util/install.sh
   - sudo make develop
   - docker pull ubuntu:trusty

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -31,7 +31,7 @@
      pip: name=pytest state=latest
 
    - name: install docker-py
-     pip: name=docker-py version=1.9.0
+     pip: name=docker-py version=1.10.6
 
    - name: built and install Containernet (using Mininet installer)
      shell: containernet/util/install.sh

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -31,7 +31,7 @@
      pip: name=pytest state=latest
 
    - name: install docker-py
-     pip: name=docker-py version=1.10.6
+     pip: name=docker version=2.0.2
 
    - name: built and install Containernet (using Mininet installer)
      shell: containernet/util/install.sh

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -686,7 +686,10 @@ class Docker ( Host ):
                      'mem_limit': -1,
                      'memswap_limit': -1,
                      'environment': {},
-                     'volumes': [] }  # use ["/home/user1/:/mnt/vol2:rw"]
+                     'volumes': [],  # use ["/home/user1/:/mnt/vol2:rw"]
+                     'publish_all_ports': True,
+                     'port_bindings': {},
+                     }
         defaults.update( kwargs )
         self.cpu_quota = defaults['cpu_quota']
         self.cpu_period = defaults['cpu_period']
@@ -697,6 +700,8 @@ class Docker ( Host ):
         self.volumes = defaults['volumes']
         self.environment = {} if defaults['environment'] is None else defaults['environment']
         self.environment.update({"PS1": chr(127)})  # CLI support
+        self.publish_all_ports = defaults['publish_all_ports']
+        self.port_bindings = defaults['port_bindings']
 
         # setup docker client
         self.dcli = docker.APIClient(base_url='unix://var/run/docker.sock')
@@ -719,7 +724,9 @@ class Docker ( Host ):
         hc = self.dcli.create_host_config(
             network_mode=None,
             privileged=True,  # we need this to allow mininet network setup
-            binds=self.volumes
+            binds=self.volumes,
+            publish_all_ports=self.publish_all_ports,
+            port_bindings=self.port_bindings
             # ATTENTION: We do not use the docker interface to set resource limits! Use self.updateCpuLimit() instead
         )
         # create new docker container

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -699,7 +699,7 @@ class Docker ( Host ):
         self.environment.update({"PS1": chr(127)})  # CLI support
 
         # setup docker client
-        self.dcli = docker.Client(base_url='unix://var/run/docker.sock')
+        self.dcli = docker.APIClient(base_url='unix://var/run/docker.sock')
 
         # pull image if it does not exist
         self._check_image_exists(dimage, True)

--- a/mininet/test/test_containernet.py
+++ b/mininet/test/test_containernet.py
@@ -62,7 +62,7 @@ class simpleTestTopology( unittest.TestCase ):
         Helper to interact with local docker instance.
         """
         if self.docker_cli is None:
-            self.docker_cli = docker.Client(
+            self.docker_cli = docker.APIClient(
                 base_url='unix://var/run/docker.sock')
         return self.docker_cli
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         'setuptools',
         'urllib3',
-        'docker-py==1.7.1',
+        'docker-py==1.10.6',
         'pytest'
     ],
     scripts=scripts,

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         'setuptools',
         'urllib3',
-        'docker-py==1.10.6',
+        'docker==2.0.2',
         'pytest'
     ],
     scripts=scripts,


### PR DESCRIPTION
-use latest docker python api version 2.0.2
this requires only a single change using the docker.APIClient (instead of docker.Client)

-bind by default the ports of the VNFs (ports exposed by EXPOSE statement in dockerfile) to a free port on the host. docker will choose an available port on the host.
-the binded portnumber can be specified also, by providing a dict to the Docker host init.
See usage documentation in docker py: https://docker-py.readthedocs.io/en/stable/api.html#module-docker.api.container

unit tests and ansible install scripts were tested on normal ubuntu 14.04 installation.