### PR TITLE
Refactor fixes and optimizations

### DIFF
--- a/mininet/cli.py
+++ b/mininet/cli.py
@@ -453,6 +453,7 @@ class CLI( Cmd ):
                     data = node.monitor()
                     output( data )
                 if not node.waiting:
+                    quietRun( 'stty isig' )
                     break
             except KeyboardInterrupt:
                 # There is an at least one race condition here, since

--- a/mininet/cli.py
+++ b/mininet/cli.py
@@ -436,7 +436,7 @@ class CLI( Cmd ):
             # Buffer by character, so that interactive
             # commands sort of work
             quietRun( 'stty -isig -icanon min 1' )
-        while True:
+        while node.shell:
             try:
                 bothPoller.poll()
                 # XXX BL: this doesn't quite do what we want.

--- a/mininet/cli.py
+++ b/mininet/cli.py
@@ -435,7 +435,7 @@ class CLI( Cmd ):
         if self.isatty():
             # Buffer by character, so that interactive
             # commands sort of work
-            quietRun( 'stty -icanon min 1' )
+            quietRun( 'stty -isig -icanon min 1' )
         while True:
             try:
                 bothPoller.poll()

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -938,10 +938,10 @@ class Docker ( Host ):
 
     def cmd(self, *args, **kwargs ):
 
-        # Allow cmd( [ list ] )
+        # Allow sendCmd( [ list ] )
         if len(args) == 1 and isinstance(args[0], list):
             cmd = args[0]
-        # Allow cmd( cmd, arg1, arg2... )
+        # Allow sendCmd( cmd, arg1, arg2... )
         elif len(args) > 0:
             cmd = args
         # Convert to string
@@ -955,18 +955,8 @@ class Docker ( Host ):
             self.waiting = False
             return ''
 
-        verbose = kwargs.get( 'verbose', False )
-        log = info if verbose else debug
-        log( '*** %s : %s\n' % ( self.name, cmd ) )
-
         exec_dict = self.dcli.exec_create(self.dc, cmd, privileged=True)
-        sout = self.dcli.exec_start(exec_dict, stream=True)
-        # Get a Generator. Fixes cmdPrint()
-        # Refer: http://docker-py.readthedocs.io/en/2.0.2/api.html
-        out = '';
-        for elm in sout:
-            log(elm);
-            out += elm;
+        out = self.dcli.exec_start(exec_dict)
         #info("cmd: {0} \noutput:{1}".format(cmd, out))
         self.waiting = False
         return out

--- a/mininet/term.py
+++ b/mininet/term.py
@@ -55,6 +55,8 @@ def makeTerm( node, title='Node', term='xterm', display=None, cmd='bash'):
     # X11 tunnel, we use terminals from outside Docker
     from mininet.node import Docker
     if isinstance( node, Docker ):
+        if not node._is_container_running():
+            return []
         if display is None:
             cmds[ term ] = cmds[ term ][:-1]
         else:


### PR DESCRIPTION
Changes:
1. Use docker.from_env().api instead of Hardcoding APIClient endpoint (https://github.com/containernet/containernet/issues/35)
2. Shift Container creation code to __init__:
This was done to make sure to clarify the purpose of startShell().
It is only meant to run the working shell for our commands. For
the container to keep running, it must halt at a dummy shell when
executing docker run from docker-py API.
3. Allow regenerating shell if necessary
4. Fixed: popen, pexec
5. Other minor bug fixes and typos
6. Fixed: SIGINT causes CLI to when running Docker Host commands (https://github.com/containernet/containernet/issues/33)
7. Added/Fixed: Maketerms (xterm/gterm) support for Docker Hosts