### PR TITLE
Add DNS as optional parameter

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -695,6 +695,7 @@ class Docker ( Host ):
                      'volumes': [],  # use ["/home/user1/:/mnt/vol2:rw"]
                      'publish_all_ports': True,
                      'port_bindings': {},
+                     'dns': [],
                      }
         defaults.update( kwargs )
 
@@ -714,6 +715,7 @@ class Docker ( Host ):
         # self.environment.update({"PS1": chr(127)})  # CLI support
         self.publish_all_ports = defaults['publish_all_ports']
         self.port_bindings = defaults['port_bindings']
+        self.dns = defaults['dns']
 
         # setup docker client
         # self.dcli = docker.APIClient(base_url='unix://var/run/docker.sock')
@@ -738,6 +740,7 @@ class Docker ( Host ):
             port_bindings=self.port_bindings,
             mem_limit=self.resources.get('mem_limit'),
             cpuset_cpus=self.resources.get('cpuset_cpus'),
+            dns=self.dns,
         )
 
         # create new docker container


### PR DESCRIPTION
Add DNS as optional parameter for container creation.
Following DockerPy API, this parameter is an array of strings specifying the IPs for DNS resolvers to be set inside the container.