### PR TITLE
Added tag to ansible installation to skip 'docker pull' when containe…

### DIFF
--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -50,3 +50,5 @@
 
    - name: download 'ubuntu' docker image for Containernet example
      shell: docker pull ubuntu:trusty
+     tags:
+        - notindocker


### PR DESCRIPTION
…rnet should be installed inside a docker container.

Signed-off-by: Manuel Peuster <manuel@peuster.de>