### PR TITLE
Fix: Wrong parameter name in docker_cpuset example.

### DIFF
--- a/examples/docker_cpuset.py
+++ b/examples/docker_cpuset.py
@@ -23,7 +23,7 @@ def topology():
     net.addController('c0')
 
     info('*** Adding docker containers\n')
-    d1 = net.addDocker('d1', ip='10.0.0.251', dimage="mpeuster/stress", cpuset="0,1")
+    d1 = net.addDocker('d1', ip='10.0.0.251', dimage="mpeuster/stress", cpuset_cpus="0,1")
     d1.sendCmd("./start.sh")
 
     info('*** Starting network\n')

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -669,7 +669,7 @@ class Docker ( Host ):
         * cpu_shares: Relative amount of max. avail CPU for container
             (not a hard limit, e.g. if only one container is busy and the rest idle)
             e.g. usage: d1=4 d2=6 <=> 40% 60% CPU
-        * cpuset: Bind containers to CPU 0 = cpu_1 ... n-1 = cpu_n
+        * cpuset_cpus: Bind containers to CPU 0 = cpu_1 ... n-1 = cpu_n (string: '0,2')
         * mem_limit: Memory limit (format: <number>[<unit>], where unit = b, k, m or g)
         * memswap_limit: Total limit = memory + swap
 


### PR DESCRIPTION
Signed-off-by: peusterm <manuel.peuster@uni-paderborn.de>