### PR TITLE
Fix: Allow port forwarding via docker's management

### DIFF
--- a/examples/dockerhosts.py
+++ b/examples/dockerhosts.py
@@ -31,7 +31,8 @@ def topology():
     d2 = net.addDocker('d2', ip='10.0.0.252', dimage="ubuntu:trusty", cpu_period=50000, cpu_quota=25000)
     d3 = net.addHost(
         'd3', ip='11.0.0.253', cls=Docker, dimage="ubuntu:trusty", cpu_shares=20)
-    d5 = net.addDocker('d5', dimage="ubuntu:trusty", volumes=["/:/mnt/vol1:rw"])
+    # using advanced features like volumes and exposed ports
+    d5 = net.addDocker('d5', dimage="ubuntu:trusty", volumes=["/:/mnt/vol1:rw"], ports=[9999], port_bindings={9999:9999}, publish_all_ports=True)
 
     info('*** Adding switch\n')
     s1 = net.addSwitch('s1')

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -693,8 +693,10 @@ class Docker ( Host ):
                      'memswap_limit': None,
                      'environment': {},
                      'volumes': [],  # use ["/home/user1/:/mnt/vol2:rw"]
+                     'network_mode': None,
                      'publish_all_ports': True,
                      'port_bindings': {},
+                     'ports': [],
                      'dns': [],
                      }
         defaults.update( kwargs )
@@ -713,6 +715,7 @@ class Docker ( Host ):
         self.environment = {} if defaults['environment'] is None else defaults['environment']
         # setting PS1 at "docker run" may break the python docker api (update_container hangs...)
         # self.environment.update({"PS1": chr(127)})  # CLI support
+        self.network_mode = defaults['network_mode']
         self.publish_all_ports = defaults['publish_all_ports']
         self.port_bindings = defaults['port_bindings']
         self.dns = defaults['dns']
@@ -728,12 +731,12 @@ class Docker ( Host ):
         debug("Created docker container object %s\n" % name)
         debug("image: %s\n" % str(self.dimage))
         debug("dcmd: %s\n" % str(self.dcmd))
-        debug("kwargs: %s\n" % str(kwargs))
+        info("%s: kwargs %s\n" % (name, str(kwargs)))
 
         # creats host config for container
         # see: https://docker-py.readthedocs.org/en/latest/hostconfig/
         hc = self.dcli.create_host_config(
-            network_mode=None,
+            network_mode=self.network_mode,
             privileged=True,  # we need this to allow mininet network setup
             binds=self.volumes,
             publish_all_ports=self.publish_all_ports,
@@ -753,6 +756,7 @@ class Docker ( Host ):
             environment=self.environment,
             #network_disabled=True,  # docker stats breaks if we disable the default network
             host_config=hc,
+            ports=defaults['ports'],
             labels=['com.containernet'],
             volumes=[self._get_volume_mount_name(v) for v in self.volumes if self._get_volume_mount_name(v) is not None],
             hostname=name


### PR DESCRIPTION
network. Ports need to be exposed AND mapped.

Signed-off-by: peusterm <manuel.peuster@uni-paderborn.de>