### PR TITLE
Support for CentOS

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -1,0 +1,1 @@
+util/docker/Dockerfile.centos7

--- a/ansible/install_centos.yml
+++ b/ansible/install_centos.yml
@@ -1,0 +1,67 @@
+- hosts: localhost
+  tasks:
+   - name: epel release
+     yum:
+       name: epel-release
+       state: latest
+
+   - name: openstack repo (for OVS)
+     yum:
+       name: centos-release-openstack-pike
+       state: latest
+   
+   - name: updates apt
+     yum:
+       name: '*'
+       state: latest
+
+   - name: install basic packages
+     yum: name={{item}} state=latest
+     with_items:
+       - gcc
+       - yum-utils
+       - device-mapper-persistent-data
+       - lvm2
+       - ca-certificates
+       - curl
+       - python-setuptools
+       - python-devel
+       - python-pip
+       - iptables
+
+   - name: install Docker CE repos (1/3)
+     shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+
+   - name: install Docker CE repos (2/3)
+     yum:
+       name: docker-ce
+     state: latest 
+
+   - name: install Docker CE repos (3/3)
+     systemd:
+       name: docker
+       state: started
+
+   - name: install pytest
+     pip: name=pytest state=latest
+
+   - name: install docker-py
+     pip: name=docker version=2.0.2
+
+   - name: install python-iptables
+     pip: name=python-iptables state=latest
+
+   - name: built and install Containernet (using Mininet installer)
+     shell: containernet/util/install.sh
+     args:
+       chdir: ../../
+
+   - name: install Containernet Python egg etc.
+     shell: make develop
+     args:
+       chdir: ../
+
+   - name: download 'ubuntu' docker image for Containernet example
+     shell: docker pull ubuntu:trusty
+     tags:
+        - notindocker

--- a/ansible/install_centos.yml
+++ b/ansible/install_centos.yml
@@ -35,7 +35,7 @@
    - name: install Docker CE repos (2/3)
      yum:
        name: docker-ce
-     state: latest 
+       state: latest 
 
    - name: install Docker CE repos (3/3)
      systemd:

--- a/ansible/install_centos.yml
+++ b/ansible/install_centos.yml
@@ -37,11 +37,6 @@
        name: docker-ce
        state: latest 
 
-   - name: install Docker CE repos (3/3)
-     systemd:
-       name: docker
-       state: started
-
    - name: install pytest
      pip: name=pytest state=latest
 

--- a/util/docker/Dockerfile.centos7
+++ b/util/docker/Dockerfile.centos7
@@ -1,0 +1,26 @@
+FROM centos:7
+
+# install required packages
+RUN yum update -y
+RUN yum install -y  git \
+    net-tools \
+    python-setuptools \
+    python-devel \
+    python-pip \
+    ansible \
+    curl \
+    iptables \
+    iputils-ping \
+    sudo \
+    initscripts
+
+# install containernet (using its Ansible playbook)
+COPY . /containernet
+WORKDIR /containernet/ansible
+RUN ansible-playbook -i "localhost," -c local --skip-tags "notindocker" install_centos.yml
+WORKDIR /containernet
+RUN python setup.py develop
+
+# Important: This entrypoint is required to start the Docker and OVS service
+ENTRYPOINT ["util/docker/entrypoint_centos.sh"]
+CMD ["python", "examples/containernet_example.py"]

--- a/util/docker/entrypoint_centos.sh
+++ b/util/docker/entrypoint_centos.sh
@@ -1,0 +1,24 @@
+#! /bin/bash -e
+
+# start OVS
+/usr/share/openvswitch/scripts/ovs-ctl start --system-id=random
+
+# check if docker socket is mounted
+if [ ! -S /var/run/docker.sock ]; then
+    echo 'Error: the Docker socket file "/var/run/docker.sock" was not found. It should be mounted as a volume.'
+    exit 1
+fi
+
+# this cannot be done from the Dockerfile since we have the socket not mounted during build
+set +e
+echo 'Pulling the "centos:7" image for later use...'
+docker pull 'centos:7'
+set -e
+
+echo "Welcome to Containernet running within a Docker container ..."
+
+if [[ $# -eq 0 ]]; then
+    exec /bin/bash
+else
+    exec $*
+fi

--- a/util/install.sh
+++ b/util/install.sh
@@ -109,7 +109,7 @@ function pre_build {
 
 function kernel {
     echo "Install Mininet-compatible kernel if necessary"
-    yum_update='sudo yum -y install'
+    yum_update='sudo yum -y update'
     apt_update='sudo apt-get update'
     if [ "$DIST" = "Fedora" -o "$DIST" = "RedHatEnterpriseServer" -o "$DIST" = "CentOS" ]; then
         $yum_update

--- a/util/install.sh
+++ b/util/install.sh
@@ -109,11 +109,12 @@ function pre_build {
 
 function kernel {
     echo "Install Mininet-compatible kernel if necessary"
-
-    if [ "$DIST" = "Fedora" -o "$DIST" = "RedHatEnterpriseServer" -o "$DIST"="CentOS" ]; then
-        sudo yum -y update
+    yum_update='sudo yum -y install'
+    apt_update='sudo apt-get update'
+    if [ "$DIST" = "Fedora" -o "$DIST" = "RedHatEnterpriseServer" -o "$DIST" = "CentOS" ]; then
+        $yum_update
     else
-        sudo apt-get update
+        $apt_update
     fi
     if ! $install linux-image-$KERNEL_NAME; then
         echo "Could not install linux-image-$KERNEL_NAME"

--- a/util/install.sh
+++ b/util/install.sh
@@ -49,7 +49,7 @@ test -e /etc/fedora-release && DIST="Fedora"
 test -e /etc/redhat-release && DIST="RedHatEnterpriseServer"
 test -e /etc/centos-release && DIST="CentOS"
 
-if [ "$DIST" = "Fedora" -o "$DIST" = "RedHatEnterpriseServer" -o "CentOS" ]; then
+if [ "$DIST" = "Fedora" -o "$DIST" = "RedHatEnterpriseServer" -o "$DIST" = "CentOS" ]; then
     install='sudo yum -y install'
     remove='sudo yum -y erase'
     pkginst='sudo rpm -ivh'
@@ -110,7 +110,7 @@ function pre_build {
 function kernel {
     echo "Install Mininet-compatible kernel if necessary"
 
-    if [ "$DIST" = "Fedora" -o "$DIST" = "RedHatEnterpriseServer" -o "CentOS" ]; then
+    if [ "$DIST" = "Fedora" -o "$DIST" = "RedHatEnterpriseServer" -o "$DIST"="CentOS" ]; then
         sudo yum -y update
     else
         sudo apt-get update


### PR DESCRIPTION
The install script for Containernet has been updated to support CentOS along RHEL and Fedora. A new Ansible script has been provided, which is specific for CentOS deployment, in addition to the Ubuntu deployment script.