### PR TITLE
Add --rm option feature to AddDocker

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -754,7 +754,7 @@ class Docker ( Host ):
         container_list = self.dcli.containers(all=True)
 
         for container in container_list:
-            for container_name in container["Names"]:
+            for container_name in container.get("Names", []):
                 if "%s.%s" % (self.dnameprefix, name) in container_name:
                     self.dcli.remove_container(container="%s.%s" % (self.dnameprefix, name), force=True)
                     break

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -656,7 +656,7 @@ class Docker ( Host ):
     """
 
     def __init__(
-            self, name, dimage, dcmd=None, **kwargs):
+            self, name, dimage, dcmd=None, rm=False, **kwargs):
         """
         Creates a Docker container as Mininet host.
 
@@ -727,6 +727,9 @@ class Docker ( Host ):
         # pull image if it does not exist
         self._check_image_exists(dimage, True)
 
+        # TODO: remove existing containers like CLI's -rm option
+        self.rm = rm
+
         # for DEBUG
         debug("Created docker container object %s\n" % name)
         debug("image: %s\n" % str(self.dimage))
@@ -745,6 +748,15 @@ class Docker ( Host ):
             cpuset_cpus=self.resources.get('cpuset_cpus'),
             dns=self.dns,
         )
+
+        # TODO: remove docker before creating it -- Jinwoo Kim
+        container_list = self.dcli.containers(all=True)
+
+        for container in container_list:
+            for container_name in container["Names"]:
+                if "%s.%s" % (self.dnameprefix, name) in container_name:
+                    self.dcli.remove_container(container="%s.%s" % (self.dnameprefix, name), force=True)
+                    break
 
         # create new docker container
         self.dc = self.dcli.create_container(

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -749,7 +749,8 @@ class Docker ( Host ):
             dns=self.dns,
         )
 
-        # TODO: remove docker before creating it -- Jinwoo Kim
+        if kwargs.get("rm", False):
+            # do the remove code here
         container_list = self.dcli.containers(all=True)
 
         for container in container_list:

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -656,7 +656,7 @@ class Docker ( Host ):
     """
 
     def __init__(
-            self, name, dimage, dcmd=None, rm=False, **kwargs):
+            self, name, dimage, dcmd=None, **kwargs):
         """
         Creates a Docker container as Mininet host.
 

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -727,9 +727,6 @@ class Docker ( Host ):
         # pull image if it does not exist
         self._check_image_exists(dimage, True)
 
-        # TODO: remove existing containers like CLI's -rm option
-        self.rm = rm
-
         # for DEBUG
         debug("Created docker container object %s\n" % name)
         debug("image: %s\n" % str(self.dimage))
@@ -750,14 +747,12 @@ class Docker ( Host ):
         )
 
         if kwargs.get("rm", False):
-            # do the remove code here
-        container_list = self.dcli.containers(all=True)
-
-        for container in container_list:
-            for container_name in container.get("Names", []):
-                if "%s.%s" % (self.dnameprefix, name) in container_name:
-                    self.dcli.remove_container(container="%s.%s" % (self.dnameprefix, name), force=True)
-                    break
+            container_list = self.dcli.containers(all=True)
+            for container in container_list:
+                for container_name in container.get("Names", []):
+                    if "%s.%s" % (self.dnameprefix, name) in container_name:
+                        self.dcli.remove_container(container="%s.%s" % (self.dnameprefix, name), force=True)
+                        break
 
         # create new docker container
         self.dc = self.dcli.create_container(


### PR DESCRIPTION
Hi,

This is a very minor requested feature, 
but I think it would be good if containernet automatically finds existing dockers which have the same name requested from AddDocker(), and remove them before creating.

I know containernet already terminates all made dockers when a user types "exit" or "Ctrl+D".
But I've got some annoying situations, for example, I needed to manually remove the container when I attached the docker session using the command "docker attach" and exit from it.

The reason was that I think containernet is not able to clean stopped containers when exiting it.

So, it turns out that there remains previously created docker containers, and this caused errors when I make a containernet again, since the stopped container has a same name.

Therefore, like the --rm option in "docker run", it would be cool if this "clean existing containers if a user wants it as an option" feature is added.

For example, AddDocker('d1', ip='10.0.0.251', dimage="ubuntu:latest", rm=True).

By the way,
I'm enjoying using containernet, and thank you for making and sharing this nice tool.

Jinwoo Kim