### PR TITLE
Cannot specify private registry with port #99

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -917,7 +917,10 @@ class Docker ( Host ):
     def _check_image_exists(self, imagename, pullImage=False):
         # split tag from repository if a tag is specified
         if ":" in imagename:
-            repo, tag = imagename.split(":")
+            #If two :, then the first is to specify a port. Otherwise, it must be a tag
+            slices = imagename.split(":")
+            repo = ":".join(slices[0:-1])
+            tag = slices[-1]
         else:
             repo = imagename
             tag = "latest"


### PR DESCRIPTION
In node.py the splitting of the dimage considers that if there is a ":" in the name, then it must be to specify the tag of the image. In my case I use a private registry with a non-default port, which needs to be specified in the dimage as well, but this breaks the splitting.

I propose to replace the
repo, tag = imagename.split(":")
for
#If two :, then the first is to specify a port. Otherwise, it must be a tag
slices = imagename.split(":")
repo = ":".join(slices[0:-1])
tag = slices[-1]
It has the downside of forcing you to specify the version in case you also want to specify the port, but it is better than breaking.