### PR TITLE
Replace `ifconfig` with `ip` for setting ip address

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -74,13 +74,13 @@ class Intf( object ):
         # mechanism and/or the way we specify IP addresses
         if '/' in ipstr:
             self.ip, self.prefixLen = ipstr.split( '/' )
-            return self.ifconfig( ipstr, 'up' )
+            return self.cmd('ip', 'address', 'add', ipstr, 'dev', self.name)
         else:
             if prefixLen is None:
                 raise Exception( 'No prefix length set for IP address %s'
                                  % ( ipstr, ) )
             self.ip, self.prefixLen = ipstr, prefixLen
-            return self.ifconfig( '%s/%s' % ( ipstr, prefixLen ) )
+            return self.cmd('ip', 'address', 'add', '%s/%s' % (ipstr, prefixLen), 'dev', self.name)
 
     def setMAC( self, macstr ):
         """Set the MAC address for an interface.


### PR DESCRIPTION
`ifconfig` in general is deprecated in modern linux and apparently
busybox/alpine based distributions error when attempting to set an ip
address with a subnet:

$ ifconfig kafka-eth0 10.0.0.97/8
ifconfig: bad address '10.0.0.97/8'

I was unable to figure out why this happens, but it does not happen with
iproute2's ip command: `ip address add 10.0.0.97/8 dev kafka-eth0`