### PR TITLE
Do not automatically start CMD, but allow to run it after init

### DIFF
--- a/examples/containernet_example_cmd_field.py
+++ b/examples/containernet_example_cmd_field.py
@@ -15,7 +15,7 @@ net.addController('c0')
 info('*** Adding docker containers\n')
 # normal container without CMD
 d1 = net.addDocker('d1', ip='10.0.0.251', dimage="ubuntu:trusty")
-# HTTPD conatiner with CMD that starts httpd in foreground
+# HTTPD container with CMD that starts httpd in foreground
 d2 = net.addDocker('d2', ip='10.0.0.252', dimage="httpd:latest")
 info('*** Adding switches\n')
 s1 = net.addSwitch('s1')
@@ -26,6 +26,7 @@ net.addLink(s1, s2, cls=TCLink, delay='100ms', bw=1)
 net.addLink(s2, d2)
 info('*** Starting network\n')
 net.start()
+d2.start()
 info('*** Running CLI\n')
 CLI(net)
 info('*** Stopping network')

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -785,28 +785,28 @@ class Docker ( Host ):
         # let's initially set our resource limits
         self.update_resources(**self.resources)
 
+    def start(self):
         # Containernet ignores the CMD field of the Dockerfile.
         # Lets try to load it here and manually execute it once the
         # container is started and configured by Containernet:
-        if not kwargs.get("no_cmd_field_execution", False):
-            cmd_field = self.get_cmd_field(self.dimage)
-            entryp_field = self.get_entrypoint_field(self.dimage)
-            if entryp_field is not None:
-                if cmd_field is None:
-                    cmd_field = list()
-                # clean up cmd_field
-                try:
-                    cmd_field.remove(u'/bin/sh')
-                    cmd_field.remove(u'-c')
-                except ValueError as ex:
-                    pass
-                # we just add the entryp. commands to the beginning:
-                cmd_field = entryp_field + cmd_field
-            if cmd_field is not None:
-                cmd_field.append("> /dev/pts/0 2>&1") # make output available to docker logs
-                cmd_field.append("&")  # put to background (works, but not nice)
-                info("{}: running CMD: {}\n".format(name, cmd_field))
-                self.cmd(" ".join(cmd_field))
+        cmd_field = self.get_cmd_field(self.dimage)
+        entryp_field = self.get_entrypoint_field(self.dimage)
+        if entryp_field is not None:
+            if cmd_field is None:
+                cmd_field = list()
+            # clean up cmd_field
+            try:
+                cmd_field.remove(u'/bin/sh')
+                cmd_field.remove(u'-c')
+            except ValueError as ex:
+                pass
+            # we just add the entryp. commands to the beginning:
+            cmd_field = entryp_field + cmd_field
+        if cmd_field is not None:
+            cmd_field.append("> /dev/pts/0 2>&1")  # make output available to docker logs
+            cmd_field.append("&")  # put to background (works, but not nice)
+            info("{}: running CMD: {}\n".format(self.name, cmd_field))
+            self.cmd(" ".join(cmd_field))
 
     def get_cmd_field(self, imagename):
         """


### PR DESCRIPTION
Immediately starting the CMD field is nice for simple, standalone
containers. However, if the containers rely on a topology described by
containernet, their starting commands are likely going to fail because
the initialization of the network did not occur at the time at which the
command is executed.

Thus, giving the user the option to launch the processes at a
well-defined state of the network allows a lot more flexibility.

This change should also remove the need of workarounds like the
`VIM_EMU_CMD` handling in vim-emu.

Related to #105 