### PR TITLE
CentOS7 docker needs iproute installed

### DIFF
--- a/examples/example-containers/Dockerfile.centos7
+++ b/examples/example-containers/Dockerfile.centos7
@@ -4,6 +4,7 @@ MAINTAINER manuel.peuster@uni-paderborn.de
 RUN yum update -y
 RUN yum install -y \
     net-tools \
+    iproute \
     iputils-ping
 
 CMD /bin/bash


### PR DESCRIPTION
On my system(s) **containernet_container_test.py** passed only when **iproute** is installed on CentOS 7 docker image.