### PR TITLE
Add tmpfs support

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -741,6 +741,7 @@ class Docker ( Host ):
                      'memswap_limit': None,
                      'environment': {},
                      'volumes': [],  # use ["/home/user1/:/mnt/vol2:rw"]
+                     'tmpfs': [], # use ["/home/vol1/:size=3G,uid=1000"]
                      'network_mode': None,
                      'publish_all_ports': True,
                      'port_bindings': {},
@@ -760,6 +761,7 @@ class Docker ( Host ):
         )
 
         self.volumes = defaults['volumes']
+        self.tmpfs = defaults['tmpfs']
         self.environment = {} if defaults['environment'] is None else defaults['environment']
         # setting PS1 at "docker run" may break the python docker api (update_container hangs...)
         # self.environment.update({"PS1": chr(127)})  # CLI support
@@ -787,6 +789,7 @@ class Docker ( Host ):
             network_mode=self.network_mode,
             privileged=True,  # we need this to allow mininet network setup
             binds=self.volumes,
+            tmpfs=self.tmpfs,
             publish_all_ports=self.publish_all_ports,
             port_bindings=self.port_bindings,
             mem_limit=self.resources.get('mem_limit'),


### PR DESCRIPTION
This passes through a tmpfs argument to the `docker.create_config(...)` method, such that a tmpfs can be added.