### PR TITLE
Enable mn for containers

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -69,6 +69,7 @@ Johannes Kampmeyer
 Marco De Benedictis
 Erik Schilling
 Zohar Lorberbaum
+Ramon Fontes
 
 
 

--- a/util/m
+++ b/util/m
@@ -9,14 +9,17 @@ else
   host=$1
 fi
 
+container=`docker ps | grep "mn.$host$" | awk '{print $10};'`
 pid=`ps ax | grep "mininet:$host$" | grep bash | grep -v mnexec | awk '{print $1};'`
 
-if echo $pid | grep -q ' '; then
-  echo "Error: found multiple mininet:$host processes"
-  exit 2
+if [ "$container" == "" ]; then
+  if echo $pid | grep -q ' '; then
+    echo "Error: found multiple mininet:$host processes"
+    exit 2
+  fi
 fi
 
-if [ "$pid" == "" ]; then
+if [ "$container" == "" ] && [ "$pid" == "" ]; then
   echo "Could not find Mininet host $host"
   exit 3
 fi
@@ -40,5 +43,9 @@ if [ -d $rootdir -a -x $rootdir/bin/bash ]; then
     cmd="chroot $rootdir /bin/bash -c $cmd"
 fi
 
-cmd="exec sudo mnexec $cg -a $pid $cmd"
+if [ "$container" != "" ]; then
+  cmd="docker exec $container bash -c '$cmd'"
+else
+  cmd="exec sudo mnexec $cg -a $pid $cmd"
+fi
 eval $cmd


### PR DESCRIPTION
This allows us to run `util/m` for containers. The code checks if the node is a container or not.