### PR TITLE
Fixed Ansible's warnings

### DIFF
--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -1,10 +1,11 @@
 - hosts: localhost
   tasks:
    - name: updates apt
-     shell: apt-get -qq update
+     apt:
+      update_cache: yes
 
    - name: install basic packages
-     apt: name={{item}} state=installed
+     apt: name={{item}} state=present
      with_items:
        - aptitude
        - apt-transport-https
@@ -18,16 +19,19 @@
        - software-properties-common
 
    - name: install Docker CE repos (1/3)
-     shell: curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+     apt_key:
+      url: https://download.docker.com/linux/ubuntu/gpg
+      state: present
 
    - name: install Docker CE repos (2/3)
      shell: add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 
    - name: install Docker CE repos (3/3)
-     shell: apt-get -qq update
+     apt:
+        update_cache: yes
 
    - name: install Docker CE
-     apt: name=docker-ce state=installed
+     apt: name=docker-ce state=present
 
    - name: find pip executable
      shell: "which pip3"


### PR DESCRIPTION
Installing containernet through ansible showed errors regarding the deprecation of the *installed* keyword in favour of the *present* keyword within the `apt` module and it also recommended using the `apt` module rather than invoking `apt-get update` through the `shell` module when updating package information. The proposed changes have been tested on my machine. No warnings are showing and the installation proceeds as usual.

We have also used the `apt_key` module instead of using the `shell` module when adding docker's key. This has been tested as well and it's working on my machine.

Thanks for your time and keep it up!