### PR TITLE
Update ansible and util/install.sh for 20.04

### DIFF
--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -53,7 +53,7 @@
      pip: name=pexpect executable={{pip_path.stdout}}
 
    - name: build and install Containernet (using Mininet installer)
-     shell: containernet/util/install.sh
+     shell: containernet/util/install.sh -fnv
      args:
        chdir: ../../
 

--- a/util/install.sh
+++ b/util/install.sh
@@ -173,7 +173,7 @@ function mn_deps {
                         python-pep8 ${PYPKG}-pexpect ${PYPKG}-tk
     else  # Debian/Ubuntu
         $install gcc make socat psmisc xterm ssh iperf telnet \
-                 cgroup-bin ethtool help2man pyflakes pylint pep8 \
+                 cgroup-tools ethtool help2man pyflakes pylint pep8 \
                  ${PYPKG}-setuptools ${PYPKG}-pexpect ${PYPKG}-tk
         $install iproute2 || $install iproute
     fi
@@ -614,7 +614,7 @@ function oftest {
     echo "Installing oftest..."
 
     # Install deps:
-    $install tcpdump python-scapy
+    $install tcpdump python3-scapy
 
     # Install oftest:
     cd $BUILD_DIR/


### PR DESCRIPTION
This PR updates the following:
- Ansible from Containernet, uses updated naming on the packages
- `util/install.sh` from Mininet, uses updated naming on the packages as well as python3 versions of scrapy

Edit: currently, this passes all tests on `sudo make test` with 3 syntax warnings.

This closes #185 .