### PR TITLE
Fix storage_opt error with old docker versions

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -751,7 +751,7 @@ class Docker ( Host ):
                      'devices': [],
                      'cap_add': [],
                      'sysctls': {},
-                     'storage_opt': {},
+                     'storage_opt': None,
                      }
         defaults.update( kwargs )
 


### PR DESCRIPTION
This is a follow up on this PR (#192)  and  fixes the issue reported here #193. 
The main problem is that an empty dictionary leads to an initialization of the `storage_opt` in older versions of the docker server (e.g. 19.03.13), even if you don't specify any `storage_opt` in the `.addDocker()` function.

For example with docker server version 19.03.13:
```python
import docker
d = docker.APIClient()
config = d.create_host_config(storage_opt={})
c = d.create_container(host_config=config, image="ubuntu:trusty")
```
The last line will lead to the following error:
```sh
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/docker/api/client.py", line 261, in _raise_for_status
    response.raise_for_status()
  File "/usr/lib/python3/dist-packages/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http+docker://localhost/v1.35/containers/create

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/docker/api/container.py", line 430, in create_container
    return self.create_container_from_config(config, name)
  File "/usr/local/lib/python3.6/dist-packages/docker/api/container.py", line 441, in create_container_from_config
    return self._result(res, True)
  File "/usr/local/lib/python3.6/dist-packages/docker/api/client.py", line 267, in _result
    self._raise_for_status(response)
  File "/usr/local/lib/python3.6/dist-packages/docker/api/client.py", line 263, in _raise_for_status
    raise create_api_error_from_http_exception(e)
  File "/usr/local/lib/python3.6/dist-packages/docker/errors.py", line 31, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation)
docker.errors.APIError: 500 Server Error: Internal Server Error ("--storage-opt is supported only for overlay over xfs with 'pquota' mount option")
```
But if we use `None` instead of an empty `dict` to initialize the `storage_opt`, all is fine. Newer versions of the docker server can also handle an empty `dict` - this is why I didn't catch that error the first time.

Now this (#193) shouldn't be a problem anymore with slightly older docker versions.