### PR TITLE
Add storage_opt to Containernet again

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -778,6 +778,7 @@ class Docker ( Host ):
         self.devices = defaults['devices']
         self.cap_add = defaults['cap_add']
         self.sysctls = defaults['sysctls']
+        self.storage_opt = defaults['storage_opt']
 
         # setup docker client
         # self.dcli = docker.APIClient(base_url='unix://var/run/docker.sock')
@@ -820,7 +821,8 @@ class Docker ( Host ):
             ipc_mode=self.ipc_mode,  # string
             devices=self.devices,  # see docker-py docu
             cap_add=self.cap_add,  # see docker-py docu
-            sysctls=self.sysctls   # see docker-py docu
+            sysctls=self.sysctls,   # see docker-py docu
+            storage_opt=self.storage_opt
             
         )
 

--- a/mininet/test/test_containernet.py
+++ b/mininet/test/test_containernet.py
@@ -650,5 +650,38 @@ class testContainernetVolumeAPI( simpleTestTopology ):
         self.stopNet()
 
 
+#@unittest.skip("disabled container storage_opt tests for development")
+class testContainernetContainerStorageOptAPI( simpleTestTopology ):
+    """
+    Test to check the storage option/limitation API of the Docker integration.
+    """
+
+    def testStorageOpt( self ):
+        """
+        d1, d2 with storage size limit
+        """
+        # create network
+        self.createNet(nswitches=1, nhosts=0, ndockers=0)
+        # add dockers
+        d0 = self.net.addDocker(
+            'd0', ip='10.0.0.1', dimage="ubuntu:trusty",
+            storage_opt={'size': '42m'})
+        d1 = self.net.addDocker(
+            'd1', ip='10.0.0.2', dimage="ubuntu:trusty",
+            storage_opt={'size': '1G'})
+        # setup links (we always need one connection to suppress warnings)
+        self.net.addLink(d0, self.s[0])
+        self.net.addLink(d1, self.s[0])
+        # start Mininet network
+        self.startNet()
+        # check number of running docker containers
+        self.assertTrue(len(self.net.hosts) == 2)
+        # check size of default docker storage partition (overlay)
+        self.assertEqual(d0.cmd("df -h | grep overlay").split()[1], "42M")
+        self.assertEqual(d1.cmd("df -h | grep overlay").split()[1], "1.0G")
+        # stop Mininet network
+        self.stopNet()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds back the `storage_opt` option to the `addDocker` function.
It refers to the original PR (#192) and a later fix of a bug (#196) which misses most of the original changes. 
Now all should be included and fine. Sorry for the inconvenience.