### PR TITLE
update git clone openflow in install.sh to prevent cloning error

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -210,7 +210,7 @@ function of {
     fi
     # was: git clone git://openflowswitch.org/openflow.git
     # Use our own fork on github for now:
-    git clone git://github.com/mininet/openflow
+    git clone https://github.com/mininet/openflow.git
     cd $BUILD_DIR/openflow
 
     # Patch controller to handle more than 16 switches


### PR DESCRIPTION
I was having the error below until I updated the git clone command on `install.sh`

```
Cloning into 'openflow'...\nfatal: unable to connect to github.com:\ngithub.com[0: 140.82.121.3]: errno=Connection refused
```

<img width="1085" alt="openflow error" src="https://user-images.githubusercontent.com/1853854/104661330-9c42bf00-56c8-11eb-8183-daef2a018409.png">
