### PR TITLE
207 topology support

### DIFF
--- a/examples/containernet_topology_example.py
+++ b/examples/containernet_topology_example.py
@@ -17,5 +17,5 @@ from mininet.topolib import TreeContainerNet
 
 if __name__ == '__main__':
     setLogLevel( 'info' )
-    network = TreeContainerNet( depth=2, fanout=32, switch=OVSSwitch )
+    network = TreeContainerNet( depth=2, fanout=100, switch=OVSSwitch )
     network.run( CLI, network )

--- a/examples/containernet_topology_example.py
+++ b/examples/containernet_topology_example.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+
+"""
+Create a 1024-host network, and run the CLI on it.
+If this fails because of kernel limits, you may have
+to adjust them, e.g. by adding entries to /etc/sysctl.conf
+and running sysctl -p. Check util/sysctl_addon.
+This is a copy of tree1024.py that is using the Containernet
+constructor. Containernet overrides the buildFromTopo
+functionality and adds Docker hosts instead.
+"""
+
+from mininet.cli import CLI
+from mininet.log import setLogLevel
+from mininet.node import OVSSwitch
+from mininet.topolib import TreeContainerNet
+
+if __name__ == '__main__':
+    setLogLevel( 'info' )
+    network = TreeContainerNet( depth=2, fanout=32, switch=OVSSwitch )
+    network.run( CLI, network )

--- a/mininet/topolib.py
+++ b/mininet/topolib.py
@@ -1,7 +1,7 @@
 "Library of potentially useful topologies for Mininet"
 
 from mininet.topo import Topo
-from mininet.net import Mininet
+from mininet.net import Mininet, Containernet
 
 # The build() method is expected to do this:
 # pylint: disable=arguments-differ
@@ -36,6 +36,12 @@ def TreeNet( depth=1, fanout=2, **kwargs ):
     "Convenience function for creating tree networks."
     topo = TreeTopo( depth, fanout )
     return Mininet( topo, **kwargs )
+
+
+def TreeContainerNet( depth=1, fanout=2, dimage="ubuntu:trusty", **kwargs ):
+    "Convenience function for creating tree networks with Docker."
+    topo = TreeTopo( depth, fanout )
+    return Containernet( topo, dimage, **kwargs )
 
 
 class TorusTopo( Topo ):


### PR DESCRIPTION
This PR changes the default Containernet constructor to allow for topology objects together with a default image.

The Containernet class overrides the `buildFromTopo` method from Mininet. The `__init__` now calls the default Mininet constructor with `build=False`, so that we can still pass the topology object but not invoke the original `buildFromTopo`.

In `topolib`, the original `TreeNet` class returns a Mininet object. In order to keep the example consistent, the PR adds a `TreeContainerNet`, which also helps to test the class changes.

The PR includes an example similar to `examples/tree1024.py` from Mininet, under `examples/containernet_topology_example.py`.

This PR closes #207 .