### PR TITLE
Change protocol for connecting to github

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -499,7 +499,7 @@ function ivs {
 
     # Install IVS from source
     cd $BUILD_DIR
-    git clone git://github.com/floodlight/ivs $IVS_SRC
+    git clone https://github.com/floodlight/ivs $IVS_SRC
     cd $IVS_SRC
     git submodule update --init
     make
@@ -527,7 +527,7 @@ function ryu {
     fi
     # fetch RYU
     cd $BUILD_DIR/
-    git clone git://github.com/osrg/ryu.git ryu
+    git clone https://github.com/osrg/ryu.git ryu
     cd ryu
 
     # install ryu
@@ -637,7 +637,7 @@ function oftest {
 
     # Install oftest:
     cd $BUILD_DIR/
-    git clone git://github.com/floodlight/oftest
+    git clone https://github.com/floodlight/oftest
 }
 
 # Install cbench
@@ -654,7 +654,7 @@ function cbench {
     cd $BUILD_DIR/
     # was:  git clone git://gitosis.stanford.edu/oflops.git
     # Use our own fork on github for now:
-    git clone git://github.com/mininet/oflops
+    git clone https://github.com/mininet/oflops
     cd oflops
     sh boot.sh || true # possible error in autoreconf, so run twice
     sh boot.sh

--- a/util/vm/install-mininet-vm.sh
+++ b/util/vm/install-mininet-vm.sh
@@ -31,7 +31,7 @@ if [ -e /etc/rc.local.backup ]; then
 fi
 # Fetch Mininet
 sudo apt-get -y install git-core openssh-server
-git clone git://github.com/mininet/mininet
+git clone https://github.com/mininet/mininet
 # Optionally check out branch
 if [ "$1" != "" ]; then
   pushd mininet


### PR DESCRIPTION
In install.sh, there are two types of `git clone`
```
git clone https://[repo url]
git clone git://[repo url]
```

If we do not set public key on github, we cannot use git://[repo url].
When I used install.sh, `Permission denied (publickey)`  occurred.
So, I changed `git://` to `https://`
