### PR TITLE
Add check if docker-ce is already installed

### DIFF
--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -18,20 +18,28 @@
        - iptables
        - software-properties-common
 
+   - name: "Check if Docker-CE is installed"
+     package_facts:
+      manager: "auto"
+
    - name: install Docker CE repos (1/3)
      apt_key:
       url: https://download.docker.com/linux/ubuntu/gpg
       state: present
+     when: "'docker-ce' not in ansible_facts.packages"
 
    - name: install Docker CE repos (2/3)
      shell: add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+     when: "'docker-ce' not in ansible_facts.packages"
 
    - name: install Docker CE repos (3/3)
      apt:
         update_cache: yes
+     when: "'docker-ce' not in ansible_facts.packages"
 
    - name: install Docker CE
      apt: name=docker-ce state=present
+     when: "'docker-ce' not in ansible_facts.packages"
 
    - name: find pip executable
      shell: "which pip3"

--- a/ansible/install_centos.yml
+++ b/ansible/install_centos.yml
@@ -34,13 +34,19 @@
        - sudo
        - which
 
+   - name: "Check if Docker-CE is installed"
+     package_facts:
+      manager: "auto"
+
    - name: install Docker CE (1/3)
      shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+     when: "'docker-ce' not in ansible_facts.packages"
 
    - name: install Docker CE (2/3)
      yum:
        name: docker-ce
        state: latest
+     when: "'docker-ce' not in ansible_facts.packages"
 
    - name: install Docker CE (3/3)
      systemd: name=docker state=started


### PR DESCRIPTION
I noticed complications if you have `docker-ce` already installed and then ansible tries to  add the repo again.
The problems seem to occur if you  have multiple instances of the docker-repo installed with different gpg keys, or something like that.

Therefor, I thought it would be clever to test if it is installed, before doing anything.