### PR TITLE
Use python 3.10 base image for server example

### DIFF
--- a/examples/example-containers/webserver_curl/Dockerfile.server
+++ b/examples/example-containers/webserver_curl/Dockerfile.server
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:2.7-slim
+FROM python:3.10-slim
 
 # Set the working directory to /app
 WORKDIR /app


### PR DESCRIPTION
Just a version bump to keep the example up to date. Example is tested with this version and works.