### PR TITLE
Fix broken Miniedit setup

### DIFF
--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -3157,7 +3157,6 @@ class MiniEdit( Frame ):
             dpctl = int(self.appPrefs['dpctl'])
         net = Containernet( topo=None,
                        listenPort=dpctl,
-                       build=False,
                        ipBase=self.appPrefs['ipBase'] )
 
         self.buildNodes(net)


### PR DESCRIPTION
Fixes #222.

The Containernet constructor passes `build=False` as default so we cannot pass it a second time.