### PR TITLE
Refactor topology

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -1048,13 +1048,11 @@ class Containernet( Mininet ):
     This class is not more than API beautification.
     """
 
-    def __init__(self, topo=None, dimage=None, **params):
+    def __init__(self, **params):
         # call original Mininet.__init__ with build=False
         # still provide any topo objects and init node lists
-        Mininet.__init__(self, build=False, **params)
+        Mininet.__init__(self, **params)
         self.SAPswitches = dict()
-        if topo and dimage:
-            self.buildFromTopo(topo, dimage)
 
     def addDocker( self, name, cls=Docker, **params ):
         """
@@ -1088,51 +1086,6 @@ class Containernet( Mininet ):
             self.addSAPNAT(SAPswitch)
 
         return SAPswitch
-
-    def buildFromTopo( self, topo=None, dimage=None ):
-        """
-        Build Containernet from a topology object. Overrides
-        buildFromTopo from Mininet class, since we need to invoke
-        addDocker here instead of addHost.
-        At the en of this function, everything should be connected
-        and up.
-        """
-
-        info( '*** Creating network\n' )
-
-        if not self.controllers and self.controller:
-            # Add a default controller
-            info( '*** Adding controller\n' )
-            classes = self.controller
-            if not isinstance( classes, list ):
-                classes = [ classes ]
-            for i, cls in enumerate( classes ):
-                # Allow Controller objects because nobody understands partial()
-                if isinstance( cls, Controller ):
-                    self.addController( cls )
-                else:
-                    self.addController( 'c%d' % i, cls )
-
-        info( '*** Adding Docker containers:\n' )
-        for hostName in topo.hosts():
-            self.addDocker( hostName, dimage=dimage, **topo.nodeInfo( hostName ) )
-            info( hostName + ' ' )
-
-        info( '\n*** Adding switches:\n' )
-        for switchName in topo.switches():
-            # A bit ugly: add batch parameter if appropriate
-            params = topo.nodeInfo( switchName )
-            cls = params.get( 'cls', self.switch )
-            self.addSwitch( switchName, **params )
-            info( switchName + ' ' )
-
-        info( '\n*** Adding links:\n' )
-        for srcName, dstName, params in topo.links(
-                sort=True, withInfo=True ):
-            self.addLink( **params )
-            info( '(%s, %s) ' % ( srcName, dstName ) )
-
-        info( '\n' )
 
     def removeExtSAP(self, sapName):
         SAPswitch = self.SAPswitches[sapName]

--- a/mininet/test/test_containernet.py
+++ b/mininet/test/test_containernet.py
@@ -715,8 +715,8 @@ class testCustomTopologies( unittest.TestCase ):
         net.start()
 
         # Assert that we can reach a container in the other network.
-        pingLostPercentage = net.hosts[0].cmd(f"ping -c 1 {otherContainerIp} | grep -oP '\\d+(?=% packet loss)'").strip()
-        self.assertEqual(pingLostPercentage, "0")
+        pingResult = net.ping([net.hosts[0]], manualdestip=otherContainerIp)
+        self.assertEqual(pingResult, 0)
 
         # We only stop this network, tearDown will take care of the extra container.
         net.stop()

--- a/mininet/test/test_containernet.py
+++ b/mininet/test/test_containernet.py
@@ -689,6 +689,8 @@ class testCustomTopologies( unittest.TestCase ):
         dropped = net.run( net.pingAll )
         self.assertEqual( dropped, 0 )
 
+    @pytest.mark.skipif(os.environ.get("CONTAINERNET_NESTED") is not None,
+                        reason="not in nested Docker deployment")
     def testNATWithTreeTopology( self ):
         # In order to test the NAT we spin up another network on the host which
         # is only accessible through a NAT in the Mininet network.


### PR DESCRIPTION
This fixes an issue brought up by #212. We refactor how custom topologies are handled to avoid overriding core Mininet methods and make sure that the topology is responsible for declaring what type of host it requires. Previously the system did not call internal config methods of Mininet which prevented eg. the NAT from working in custom topologies.