### PR TITLE
Add Ubuntu 20.04-based Dockerfile for nested deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         - system: Ubuntu 18.04
           tag: containernet/containernet:ubuntu
           dockerfile: ./Dockerfile
+        - system: Ubuntu 20.04
+          tag: containernet/containernet:ubuntu2004
+          dockerfile: ./Dockerfile
         - system: CentOS 7
           tag: containernet/containernet:centos7
           dockerfile: ./Dockerfile.centos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           dockerfile: ./Dockerfile
         - system: Ubuntu 20.04
           tag: containernet/containernet:ubuntu2004
-          dockerfile: ./Dockerfile
+          dockerfile: ./Dockerfile.focal
         - system: CentOS 7
           tag: containernet/containernet:centos7
           dockerfile: ./Dockerfile.centos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-${{ matrix.ubuntu }}
     steps:
     - uses: actions/checkout@v2
+    - name: Update APT
+      run: sudo apt-get update
     - name: Run Ansible Playbook
       run: |
         sudo apt-get -y install ansible vlan 
@@ -42,7 +44,9 @@ jobs:
     name: Run tests in ${{ matrix.container.system }} container
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - name: Update APT
+      run: sudo apt-get update
     # OVS needs to install a kernel module. We do not want to allow
     # the container to modify the kernel so we install it before.
     - name: Install OVS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,11 @@ jobs:
       run: |
         sudo apt-get -y install openvswitch-switch
     - name: Build container
-      run: |
-        docker build -t ${{ matrix.container.tag }} -f ${{ matrix.container.dockerfile }} .
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ${{ matrix.container.dockerfile }}
+        tags: ${{ matrix.container.tag }}
     - name: Run tests in container
       run: |
         docker run --name containernet -i --rm --privileged \

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -1,5 +1,7 @@
 FROM ubuntu:focal
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # install required packages
 RUN apt-get clean
 RUN apt-get update \

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -1,0 +1,32 @@
+FROM ubuntu:focal
+
+# install required packages
+RUN apt-get clean
+RUN apt-get update \
+    && apt-get install -y  git \
+    net-tools \
+    aptitude \
+    build-essential \
+    python3-setuptools \
+    python3-dev \
+    python3-pip \
+    software-properties-common \
+    ansible \
+    curl \
+    iptables \
+    iputils-ping \
+    sudo
+
+# install containernet (using its Ansible playbook)
+COPY . /containernet
+WORKDIR /containernet/ansible
+RUN ansible-playbook -i "localhost," -c local --skip-tags "notindocker" install.yml
+WORKDIR /containernet
+RUN make develop
+
+# tell containernet that it runs in a container
+ENV CONTAINERNET_NESTED 1
+
+# Important: This entrypoint is required to start the OVS service
+ENTRYPOINT ["util/docker/entrypoint.sh"]
+CMD ["python3", "examples/containernet_example.py"]


### PR DESCRIPTION
This PR:
- Adds docker image for nested deployment based on Ubuntu 20.04
- Adds Ubuntu 20.04-based docker image to CI
- Rewrites current CI to use [GH action](https://github.com/docker/build-push-action) for building docker images