### PR TITLE
Enhance Ansible Playbook script

### DIFF
--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -5,12 +5,13 @@
       update_cache: yes
 
    - name: install basic packages
-     apt: name={{item}} state=present
-     name: [
-       'aptitude', 'apt-transport-https', 'ca-certificates',
-       'curl', 'python3-setuptools', 'python3-dev', 'build-essential',
-       'python3-pip','iptables','software-properties-common'
-       ]
+     apt:
+      name: [
+        'aptitude', 'apt-transport-https', 'ca-certificates',
+        'curl', 'python3-setuptools', 'python3-dev', 'build-essential',
+        'python3-pip','iptables','software-properties-common'
+        ]
+      state: present
 
    - name: "Check if Docker-CE is installed"
      package_facts:

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -24,27 +24,27 @@
 
    - name: Add Docker CE repository key
      shell: "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg"
-     when: "'docker-ce' not in ansible_facts.packages"
+     when: "'docker-ce' not in ansible_facts.packages and 'moby-engine' not in ansible_facts.packages"
 
    - name: Check system architecture
      shell: "dpkg --print-architecture"
      register: arch
-     when: "'docker-ce' not in ansible_facts.packages"
+     when: "'docker-ce' not in ansible_facts.packages and 'moby-engine' not in ansible_facts.packages"
    
    - name: Check OS Codename
      shell: "lsb_release -cs"
      register: codename
-     when: "'docker-ce' not in ansible_facts.packages"
+     when: "'docker-ce' not in ansible_facts.packages and 'moby-engine' not in ansible_facts.packages"
      
    - name: Install Docker CE repository
      apt_repository:
        repo: "deb [arch={{arch.stdout}} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu {{codename.stdout}} stable"
        filename: "docker"
-     when: "'docker-ce' not in ansible_facts.packages"
+     when: "'docker-ce' not in ansible_facts.packages and 'moby-engine' not in ansible_facts.packages"
 
    - name: install Docker CE
      apt: name=docker-ce state=present
-     when: "'docker-ce' not in ansible_facts.packages"
+     when: "'docker-ce' not in ansible_facts.packages and 'moby-engine' not in ansible_facts.packages"
 
    - name: find pip executable
      shell: "which pip3"

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -22,19 +22,24 @@
      package_facts:
       manager: "auto"
 
-   - name: install Docker CE repos (1/3)
-     apt_key:
-      url: https://download.docker.com/linux/ubuntu/gpg
-      state: present
+   - name: Add Docker CE repository key
+     shell: "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg"
      when: "'docker-ce' not in ansible_facts.packages"
 
-   - name: install Docker CE repos (2/3)
-     shell: add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+   - name: Check system architecture
+     shell: "dpkg --print-architecture"
+     register: arch
      when: "'docker-ce' not in ansible_facts.packages"
-
-   - name: install Docker CE repos (3/3)
-     apt:
-        update_cache: yes
+   
+   - name: Check OS Codename
+     shell: "lsb_release -cs"
+     register: codename
+     when: "'docker-ce' not in ansible_facts.packages"
+     
+   - name: Install Docker CE repository
+     apt_repository:
+       repo: "deb [arch={{arch.stdout}} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu {{codename.stdout}} stable"
+       filename: "docker"
      when: "'docker-ce' not in ansible_facts.packages"
 
    - name: install Docker CE

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -6,17 +6,11 @@
 
    - name: install basic packages
      apt: name={{item}} state=present
-     with_items:
-       - aptitude
-       - apt-transport-https
-       - ca-certificates
-       - curl
-       - python3-setuptools
-       - python3-dev
-       - build-essential
-       - python3-pip
-       - iptables
-       - software-properties-common
+     name: [
+       'aptitude', 'apt-transport-https', 'ca-certificates',
+       'curl', 'python3-setuptools', 'python3-dev', 'build-essential',
+       'python3-pip','iptables','software-properties-common'
+       ]
 
    - name: "Check if Docker-CE is installed"
      package_facts:


### PR DESCRIPTION
This PR:
- Removes use of `apt-key` (which is deprecated)
- Updates docker installation accordingly