### PR TITLE
Removed an unnecessary print statement.

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1104,7 +1104,7 @@ class Docker ( Host ):
         Checks if the repo:tag image exists locally
         :return: True if the image exists locally. Else false.
         """
-        print("1: ")
+        debug("Checking if the image exists locally.")
         images = self.dcli.images()
         imageTag = "%s:%s" % (repo, tag)
         for image in images:


### PR DESCRIPTION
The current codebase will print out "1:" in all log modes.