### PR TITLE
Mitigation for flaky Ubuntu 20.04 Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         ubuntu: ["18.04"]
         flaky: [false]
         include:
-          ubuntu: "20.04"
+        - ubuntu: "20.04"
           flaky: true
 
     name: Run tests on Ubuntu ${{ matrix.ubuntu }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu: ["18.04", "20.04"]
+        ubuntu: ["18.04"]
+        flaky: [false]
+        include:
+          ubuntu: "20.04"
+          flaky: true
 
     name: Run tests on Ubuntu ${{ matrix.ubuntu }}
     runs-on: ubuntu-${{ matrix.ubuntu }}
@@ -23,6 +27,7 @@ jobs:
         cd ansible
         sudo ansible-playbook -i "localhost," -c local install.yml
     - name: Run Tests
+      continue-on-error: ${{ matrix.flaky }}
       run: |
         sudo pytest -v mininet/test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         ubuntu: ["18.04", "20.04"]
 
@@ -27,6 +28,7 @@ jobs:
 
   test-in-nested-container:
     strategy:
+      fail-fast: false
       matrix:
         container:
         - system: Ubuntu 18.04


### PR DESCRIPTION
- Disables [`fail-fast`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) behavior with matrices to stop GH from cancelling all jobs within same matrix
- Closes #231: Suppress error from testing in Ubuntu 20.04 by using [`continue-on-error`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error)