### PR TITLE
Disable fail-fast behavior of test matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         ubuntu: ["18.04", "20.04"]
 
@@ -29,6 +30,7 @@ jobs:
 
   test-in-nested-container:
     strategy:
+      fail-fast: false
       matrix:
         container:
         - system: Ubuntu 18.04


### PR DESCRIPTION
Cherry-picked from #245
This PR disables [`fail-fast`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) behavior with matrices to stop GH from cancelling all jobs within the same matrix.