### PR TITLE
Enable setting container in privileged mode as an argument

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -761,6 +761,7 @@ class Docker ( Host ):
                      'dns': [],
                      'ipc_mode': None,
                      'devices': [],
+                     'privileged': False,
                      'cap_add': ['net_admin'],  # we need this to allow mininet network setup
                      'storage_opt': None,
                      'sysctls': {}
@@ -794,6 +795,7 @@ class Docker ( Host ):
         self.cap_add = defaults['cap_add']
         self.sysctls = defaults['sysctls']
         self.storage_opt = defaults['storage_opt']
+        self.privileged = defaults['privileged']
 
         # setup docker client
         # self.dcli = docker.APIClient(base_url='unix://var/run/docker.sock')
@@ -825,7 +827,7 @@ class Docker ( Host ):
         # see: https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config
         hc = self.dcli.create_host_config(
             network_mode=self.network_mode,
-            privileged=False,  # no longer need privileged, using net_admin capability instead
+            privileged=self.privileged,
             binds=self.volumes,
             tmpfs=self.tmpfs,
             publish_all_ports=self.publish_all_ports,


### PR DESCRIPTION
Right now, the privileged flag for creating containers is force set to False.
This changes allows users to change this by adding the kwarg privileged=True when creating a new container Host.