### PR TITLE
check for in docker deployment before setting cgroup

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -820,6 +820,11 @@ class Docker ( Host ):
         debug("image: %s\n" % str(self.dimage))
         debug("dcmd: %s\n" % str(self.dcmd))
         info("%s: kwargs %s\n" % (name, str(kwargs)))
+        
+        cgroup_parent = '/docker'
+        if os.environ.get("CONTAINERNET_NESTED") == "1":  # Check if containernet is in a docker container and remove cgoup_parent if true
+            cgroup_parent = None
+
 
         # creats host config for container
         # see: https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_host_config
@@ -840,7 +845,7 @@ class Docker ( Host ):
             storage_opt=self.storage_opt,
             # Assuming Docker uses the cgroupfs driver, we set the parent to safely
             # access cgroups when modifying resource limits.
-            cgroup_parent='/docker'
+            cgroup_parent=cgroup_parent
         )
 
         if kwargs.get("rm", False):


### PR DESCRIPTION
Creating a docker container from the current master branch works, but when trying to run containernet within the docker container, it does not work, failing with the error

### docker.errors.APIError: 400 Client Error: Bad Request ("cgroup-parent for systemd cgroup should be a valid slice named as "xxx.slice"")

The reason for this is the setting of cgroup_parent='/docker' when creating a new Docker Host.

The proposed changes check for the "CONTAINERNET_NESTED" environment variable and if it is set to 1. If true, cgroup_parent will be set to None, allowing execution in docker containers again.